### PR TITLE
Fix Jacobian calculation for revolute joints

### DIFF
--- a/pytorch_kinematics/jacobian.py
+++ b/pytorch_kinematics/jacobian.py
@@ -34,12 +34,6 @@ def calc_jacobian(serial_chain, th, tool=None):
     for f in reversed(serial_chain._serial_frames):
         if f.joint.joint_type == "revolute":
             cnt += 1
-            d = torch.stack([-cur_transform[:, 0, 0] * cur_transform[:, 1, 3]
-                             + cur_transform[:, 1, 0] * cur_transform[:, 0, 3],
-                             -cur_transform[:, 0, 1] * cur_transform[:, 1, 3]
-                             + cur_transform[:, 1, 1] * cur_transform[:, 0, 3],
-                             -cur_transform[:, 0, 2] * cur_transform[:, 1, 3]
-                             + cur_transform[:, 1, 2] * cur_transform[:, 0, 3]]).transpose(0, 1)
             axis_in_flange = cur_transform[:, :3, :3].transpose(1, 2) @ f.joint.axis 
             joint_to_eef_in_flange = cur_transform[:, :3, :3].transpose(1,2) @ cur_transform[:, :3, 3].unsqueeze(2)
             d = torch.cross(axis_in_flange, joint_to_eef_in_flange.squeeze(2), dim=1)

--- a/pytorch_kinematics/jacobian.py
+++ b/pytorch_kinematics/jacobian.py
@@ -41,11 +41,10 @@ def calc_jacobian(serial_chain, th, tool=None):
                              + cur_transform[:, 1, 1] * cur_transform[:, 0, 3],
                              -cur_transform[:, 0, 2] * cur_transform[:, 1, 3]
                              + cur_transform[:, 1, 2] * cur_transform[:, 0, 3]]).transpose(0, 1)
-            # rows are the joint axis in the flange frame
             axis_in_flange = cur_transform[:, :3, :3].transpose(1, 2) @ f.joint.axis 
-            joint_to_eef_in_flange = cur_transform[:, :3, :3].transpose(1,2) @ cur_transform[:, :3, 3].T
+            joint_to_eef_in_flange = cur_transform[:, :3, :3].transpose(1,2) @ cur_transform[:, :3, 3].unsqueeze(2)
             d = torch.cross(axis_in_flange, joint_to_eef_in_flange.squeeze(2), dim=1)
-            delta = axis_in_flange #cur_transform[:, 2, 0:3]
+            delta = axis_in_flange
             j_fl[:, :, -cnt] = torch.cat((d, delta), dim=-1)
         elif f.joint.joint_type == "prismatic":
             cnt += 1

--- a/pytorch_kinematics/jacobian.py
+++ b/pytorch_kinematics/jacobian.py
@@ -1,3 +1,4 @@
+from re import A
 import torch
 from pytorch_kinematics import transforms
 
@@ -40,7 +41,11 @@ def calc_jacobian(serial_chain, th, tool=None):
                              + cur_transform[:, 1, 1] * cur_transform[:, 0, 3],
                              -cur_transform[:, 0, 2] * cur_transform[:, 1, 3]
                              + cur_transform[:, 1, 2] * cur_transform[:, 0, 3]]).transpose(0, 1)
-            delta = cur_transform[:, 2, 0:3]
+            # rows are the joint axis in the flange frame
+            axis_in_flange = cur_transform[:, :3, :3] @ f.joint.axis 
+            joint_to_eef_in_flange = -cur_transform[:, :3, :3].transpose(1,2) @ cur_transform[:, :3, 3].T
+            d = torch.cross(axis_in_flange, joint_to_eef_in_flange.squeeze(2), dim=1)
+            delta = axis_in_flange #cur_transform[:, 2, 0:3]
             j_fl[:, :, -cnt] = torch.cat((d, delta), dim=-1)
         elif f.joint.joint_type == "prismatic":
             cnt += 1

--- a/pytorch_kinematics/jacobian.py
+++ b/pytorch_kinematics/jacobian.py
@@ -42,8 +42,8 @@ def calc_jacobian(serial_chain, th, tool=None):
                              -cur_transform[:, 0, 2] * cur_transform[:, 1, 3]
                              + cur_transform[:, 1, 2] * cur_transform[:, 0, 3]]).transpose(0, 1)
             # rows are the joint axis in the flange frame
-            axis_in_flange = cur_transform[:, :3, :3] @ f.joint.axis 
-            joint_to_eef_in_flange = -cur_transform[:, :3, :3].transpose(1,2) @ cur_transform[:, :3, 3].T
+            axis_in_flange = cur_transform[:, :3, :3].transpose(1, 2) @ f.joint.axis 
+            joint_to_eef_in_flange = cur_transform[:, :3, :3].transpose(1,2) @ cur_transform[:, :3, 3].T
             d = torch.cross(axis_in_flange, joint_to_eef_in_flange.squeeze(2), dim=1)
             delta = axis_in_flange #cur_transform[:, 2, 0:3]
             j_fl[:, :, -cnt] = torch.cat((d, delta), dim=-1)

--- a/pytorch_kinematics/jacobian.py
+++ b/pytorch_kinematics/jacobian.py
@@ -1,4 +1,3 @@
-from re import A
 import torch
 from pytorch_kinematics import transforms
 

--- a/tests/simple_y_arm.urdf
+++ b/tests/simple_y_arm.urdf
@@ -4,36 +4,36 @@
     </link>
 
     <link name="arm">
-    <visual>
-        <geometry>
-        <box size="0.6 0.1 0.2"/>
-        </geometry>
-    </visual>
+        <visual>
+            <geometry>
+                <box size="0.6 0.1 0.2"/>
+            </geometry>
+        </visual>
     </link>
 
     <link name="eef">
-    <visual>
-        <geometry>
-            <box size="0.2 0.2 0.2"/>
-        </geometry>
-        <material name="Cyan">
-            <color rgba="0 1.0 1.0 1.0"/>
-        </material>
-    </visual>
+        <visual>
+            <geometry>
+                <box size="0.2 0.2 0.2"/>
+            </geometry>
+            <material name="Cyan">
+                <color rgba="0 1.0 1.0 1.0"/>
+            </material>
+        </visual>
     </link>
 
     <joint name="base_to_arm" type="revolute">
-    <parent link="base_link"/>
+        <parent link="base_link"/>
         <child link="arm"/>
         <axis xyz="0 1 0"/>
         <limit lower="0.0" upper="0.548" effort="1000.0" velocity="0.5"/>
     </joint>
-    
+
     <joint name="arm_to_eef" type="fixed">
         <parent link="arm"/>
         <child link="eef"/>
         <origin xyz="0.3 0.0 0.0"/>
     </joint>
-    
+
 
 </robot>

--- a/tests/simple_y_arm.urdf
+++ b/tests/simple_y_arm.urdf
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<robot name="simple">
+    <link name="base_link">
+    </link>
+
+    <link name="arm">
+    <visual>
+        <geometry>
+        <box size="0.6 0.1 0.2"/>
+        </geometry>
+    </visual>
+    </link>
+
+    <link name="eef">
+    <visual>
+        <geometry>
+            <box size="0.2 0.2 0.2"/>
+        </geometry>
+        <material name="Cyan">
+            <color rgba="0 1.0 1.0 1.0"/>
+        </material>
+    </visual>
+    </link>
+
+    <joint name="base_to_arm" type="revolute">
+    <parent link="base_link"/>
+        <child link="arm"/>
+        <axis xyz="0 1 0"/>
+        <limit lower="0.0" upper="0.548" effort="1000.0" velocity="0.5"/>
+    </joint>
+    
+    <joint name="arm_to_eef" type="fixed">
+        <parent link="arm"/>
+        <child link="eef"/>
+        <origin xyz="0.3 0.0 0.0"/>
+    </joint>
+    
+
+</robot>

--- a/tests/test_jacobian.py
+++ b/tests/test_jacobian.py
@@ -66,8 +66,7 @@ def test_jacobian_at_different_loc_than_ee():
     assert torch.allclose(J, torch.cat((J_c1, J_c2)), atol=1e-7)
 
 def test_jacobian_y_joint_axis():
-    chain = pk.build_serial_chain_from_urdf(open(os.path.join(cfg.TEST_DIR, "simple_y_arm.urdf")).read(),
-                                            "eef")
+    chain = pk.build_serial_chain_from_urdf(open(os.path.join(cfg.TEST_DIR, "simple_y_arm.urdf")).read(), "eef")
     th = torch.tensor([0])
     J = chain.jacobian(th)
     J_c3 = torch.tensor([ [ [0.], [0.], [-0.3], [0.], [1.], [0.] ] ])

--- a/tests/test_jacobian.py
+++ b/tests/test_jacobian.py
@@ -65,6 +65,14 @@ def test_jacobian_at_different_loc_than_ee():
     J = chain.jacobian(th, locations=loc)
     assert torch.allclose(J, torch.cat((J_c1, J_c2)), atol=1e-7)
 
+def test_jacobian_y_joint_axis():
+    chain = pk.build_serial_chain_from_urdf(open(os.path.join(cfg.TEST_DIR, "simple_y_arm.urdf")).read(),
+                                            "eef")
+    th = torch.tensor([0])
+    J = chain.jacobian(th)
+    J_c3 = torch.tensor([ [ [0.], [0.], [-0.3], [0.], [1.], [0.] ] ])
+    assert torch.allclose(J, J_c3, atol=1e-7)
+
 
 def test_parallel():
     N = 100


### PR DESCRIPTION
The jacobian calculation assumed the joint rotation axis was always +z for revolute joints. This fixes that. I've also checked that all the test cases are still passing with this change.