### PR TITLE
make the dm_control dependency opt-in

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install .
+        python -m pip install .[test]
         python -m pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Lint with flake8

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 # Installation
 ```shell
 pip install pytorch-kinematics
+# Alternatively, if you want to load from mujoco's XML format, use:
+pip install pytorch-kinematics[mujoco]
 ```
 
 For development, clone repository somewhere, then `pip3 install -e .` to install in editable mode.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ dependencies = [# Optional
     'transformations',
     'absl-py',
     'lxml',
-    'dm_control',
     'pyyaml'
 ]
 
@@ -71,6 +70,7 @@ dependencies = [# Optional
 # projects.
 [project.optional-dependencies] # Optional
 test = ["pytest"]
+mujoco = ["dm_control"]
 
 # List URLs that are relevant to your project
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ dependencies = [# Optional
 # Similar to `dependencies` above, these must be valid existing
 # projects.
 [project.optional-dependencies] # Optional
-test = ["pytest"]
+test = ["pytest", "dm_control"]
 mujoco = ["dm_control"]
 
 # List URLs that are relevant to your project

--- a/src/pytorch_kinematics/mjcf.py
+++ b/src/pytorch_kinematics/mjcf.py
@@ -1,5 +1,3 @@
-from dm_control import mjcf
-
 import pytorch_kinematics.transforms as tf
 from . import chain
 from . import frame
@@ -59,6 +57,8 @@ def build_chain_from_mjcf(data):
     chain.Chain
         Chain object created from MJCF.
     """
+    from dm_control import mjcf
+
     model = mjcf.from_xml_string(data)
     root_body = model.worldbody.body[0]
     root_frame = frame.Frame(root_body.name + "_frame",


### PR DESCRIPTION
`dm_control` depends on out of date versions of packages like `pyparsing`, so most people probably don't want it by default.