### PR TITLE
Extracting velocity and effort limits from URDF

### DIFF
--- a/src/pytorch_kinematics/chain.py
+++ b/src/pytorch_kinematics/chain.py
@@ -404,16 +404,14 @@ class Chain:
     def _get_joint_limits(self, param_name):
         low = []
         high = []
-        # Min and max velocity and effor default to +/- inf
-        default = np.inf
-        if param_name == "limits":
-            # Min and max joint limits default to +/- pi
-            default = np.pi
         for joint in self.get_joints():
             val = getattr(joint, param_name)
             if val is None:
-                low.append(-default)
-                high.append(default)
+                # NOTE: This changes the previous default behavior of returning
+                # +/- np.pi for joint limits to be more natural for both
+                # revolute and prismatic joints
+                low.append(-np.inf)
+                high.append(np.inf)
             else:
                 low.append(val[0])
                 high.append(val[1])

--- a/src/pytorch_kinematics/chain.py
+++ b/src/pytorch_kinematics/chain.py
@@ -393,17 +393,30 @@ class Chain:
         return torch.clamp(th, self.low, self.high)
 
     def get_joint_limits(self):
+        return self._get_joint_limits("limits")
+
+    def get_joint_velocity_limits(self):
+        return self._get_joint_limits("velocity_limits")
+
+    def get_joint_effort_limits(self):
+        return self._get_joint_limits("effort_limits")
+
+    def _get_joint_limits(self, param_name):
         low = []
         high = []
-        for joint_name in self.get_joint_parameter_names(exclude_fixed=True):
-            joint = self.find_joint(joint_name)
-            if joint.limits is None:
-                low.append(-np.pi)
-                high.append(np.pi)
+        # Min and max velocity and effor default to +/- inf
+        default = np.inf
+        if param_name == "limits":
+            # Min and max joint limits default to +/- pi
+            default = np.pi
+        for joint in self.get_joints():
+            val = getattr(joint, param_name)
+            if val is None:
+                low.append(-default)
+                high.append(default)
             else:
-                low.append(joint.limits[0])
-                high.append(joint.limits[1])
-
+                low.append(val[0])
+                high.append(val[1])
         return low, high
 
     @staticmethod

--- a/src/pytorch_kinematics/frame.py
+++ b/src/pytorch_kinematics/frame.py
@@ -45,7 +45,8 @@ class Joint(object):
     TYPES = ['fixed', 'revolute', 'prismatic']
 
     def __init__(self, name=None, offset=None, joint_type='fixed', axis=(0.0, 0.0, 1.0),
-                 dtype=torch.float32, device="cpu", limits=None):
+                 dtype=torch.float32, device="cpu", limits=None,
+                 velocity_limits=None, effort_limits=None):
         if offset is None:
             self.offset = None
         else:
@@ -65,6 +66,8 @@ class Joint(object):
         self.axis = self.axis / self.axis.norm()
 
         self.limits = limits
+        self.velocity_limits = velocity_limits
+        self.effort_limits = effort_limits
 
     def to(self, *args, **kwargs):
         self.axis = self.axis.to(*args, **kwargs)

--- a/src/pytorch_kinematics/urdf.py
+++ b/src/pytorch_kinematics/urdf.py
@@ -49,9 +49,19 @@ def _build_chain_recurse(root_frame, lmap, joints):
                 limits = (j.limit.lower, j.limit.upper)
             except AttributeError:
                 limits = None
+            # URDF assumes symmetric velocity and effort limits
+            try:
+                velocity_limits = (-j.limit.velocity, j.limit.velocity)
+            except AttributeError:
+                velocity_limits = None
+            try:
+                effort_limits = (-j.limit.effort, j.limit.effort)
+            except AttributeError:
+                effort_limits = None
             child_frame = frame.Frame(j.child)
             child_frame.joint = frame.Joint(j.name, offset=_convert_transform(j.origin),
-                                            joint_type=JOINT_TYPE_MAP[j.type], axis=j.axis, limits=limits)
+                                            joint_type=JOINT_TYPE_MAP[j.type], axis=j.axis, limits=limits,
+                                            velocity_limits=velocity_limits, effort_limits=effort_limits)
             link = lmap[j.child]
             child_frame.link = frame.Link(link.name, offset=_convert_transform(link.origin),
                                           visuals=[_convert_visual(link.visual)])

--- a/tests/joint_limit_robot.urdf
+++ b/tests/joint_limit_robot.urdf
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<robot name="joint_limit_robot">
+    <!-- 
+        This robot is designed just to test that the velocity and effort limits
+        are captured properly. It consists of revolute, prismatic, and fixed
+        joints, is not a serial chain, and algorithmically defines velocity
+        and effort limits as a function of the joint number (v = j, e = j + 4)
+        for easy validation.
+    -->
+    <link name="link1" />
+    <link name="link2" />
+    <link name="link3" />
+    <link name="link4" />
+    <link name="link5" />
+    <link name="link6" />
+
+    <joint name="joint1" type="revolute">
+        <origin xyz="0.0 0.0 1.0"/>
+        <axis xyz="0 0 1"/>
+        <limit lower="-0.5" upper="0.5" effort="5" velocity="1"/>
+        <parent link="link1"/>
+        <child link="link2"/>
+    </joint>
+    <joint name="joint2" type="prismatic">
+        <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
+        <axis xyz="1 0 0"/>
+        <limit lower="0" upper="0.5" effort="6" velocity="2"/>
+        <parent link="link2"/>
+        <child link="link3"/>
+    </joint>
+    <joint name="joint3" type="revolute">
+        <origin xyz="0.0 0.0 0.0" rpy="0 0 1.57079632679"/>
+        <axis xyz="0 1 0"/>
+        <limit lower="-0.5" upper="0.5" effort="7" velocity="3"/>
+        <parent link="link3"/>
+        <child link="link4"/>
+    </joint>
+    <joint name="joint4" type="revolute">
+        <origin xyz="0.0 0.0 0.0" rpy="0 0 -1.57079632679"/>
+        <axis xyz="0 1 0"/>
+        <limit lower="-0.5" upper="0.5" effort="8" velocity="4"/>
+        <parent link="link3"/>
+        <child link="link5"/>
+    </joint>
+    <joint name="joint5" type="fixed">
+        <parent link="link5"/>
+        <child link="link6"/>
+        <origin xyz="0.3 0.0 0.0"/>
+    </joint>
+
+</robot>

--- a/tests/joint_no_limit_robot.urdf
+++ b/tests/joint_no_limit_robot.urdf
@@ -1,11 +1,12 @@
 <?xml version="1.0"?>
 <robot name="joint_limit_robot">
-    <!-- 
+    <!--
         This robot is designed just to test that the velocity and effort limits
         are captured properly. It consists of revolute, prismatic, and fixed
-        joints, is not a serial chain, and algorithmically defines joint,
+        joints, is not a serial chain, and algorithmically defines
         velocity and effort limits as a function of the joint number
-        (low = j + 8, high = j + 9, v = j, e = j + 4) for easy validation.
+        (v = j, e = j + 4) for easy validation. All joint limits are
+        unspecified.
     -->
     <link name="link1" />
     <link name="link2" />
@@ -17,28 +18,28 @@
     <joint name="joint1" type="revolute">
         <origin xyz="0.0 0.0 1.0"/>
         <axis xyz="0 0 1"/>
-        <limit lower="9" upper="10" effort="5" velocity="1"/>
+        <limit effort="5" velocity="1"/>
         <parent link="link1"/>
         <child link="link2"/>
     </joint>
     <joint name="joint2" type="prismatic">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 0"/>
         <axis xyz="1 0 0"/>
-        <limit lower="10" upper="11" effort="6" velocity="2"/>
+        <limit effort="6" velocity="2"/>
         <parent link="link2"/>
         <child link="link3"/>
     </joint>
     <joint name="joint3" type="revolute">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 1.57079632679"/>
         <axis xyz="0 1 0"/>
-        <limit lower="11" upper="12" effort="7" velocity="3"/>
+        <limit effort="7" velocity="3"/>
         <parent link="link3"/>
         <child link="link4"/>
     </joint>
     <joint name="joint4" type="revolute">
         <origin xyz="0.0 0.0 0.0" rpy="0 0 -1.57079632679"/>
         <axis xyz="0 1 0"/>
-        <limit lower="12" upper="13" effort="8" velocity="4"/>
+        <limit effort="8" velocity="4"/>
         <parent link="link3"/>
         <child link="link5"/>
     </joint>

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,0 +1,25 @@
+import os
+
+import pytorch_kinematics as pk
+
+TEST_DIR = os.path.dirname(__file__)
+
+def test_limits():
+    chain = pk.build_serial_chain_from_urdf(open(os.path.join(TEST_DIR, "kuka_iiwa.urdf")).read(), "lbr_iiwa_link_7")
+    for joint in chain.get_joints():
+        # Default velocity and effort limits for the iiwa arm
+        assert joint.velocity_limits == (-10, 10)
+        assert joint.effort_limits == (-300, 300)
+    chain = pk.build_chain_from_urdf(open(os.path.join(TEST_DIR, "joint_limit_robot.urdf")).read())
+    for joint in chain.get_joints():
+        # Slice off the "joint" prefix to get just the number of the joint
+        num = int(joint.name[5])
+        # This robot is defined specifically to test joint limits. It always
+        # sets velocity limits equal to the joint number and effort limits
+        # equal to the joint number + 4
+        assert joint.velocity_limits == (-num, num)
+        assert joint.effort_limits == (-(num + 4), num + 4)
+
+
+if __name__ == "__main__":
+    test_limits()

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -6,20 +6,65 @@ TEST_DIR = os.path.dirname(__file__)
 
 def test_limits():
     chain = pk.build_serial_chain_from_urdf(open(os.path.join(TEST_DIR, "kuka_iiwa.urdf")).read(), "lbr_iiwa_link_7")
+    iiwa_low_individual = []
+    iiwa_high_individual = []
     for joint in chain.get_joints():
         # Default velocity and effort limits for the iiwa arm
         assert joint.velocity_limits == (-10, 10)
         assert joint.effort_limits == (-300, 300)
+        iiwa_low_individual.append(joint.limits[0])
+        iiwa_high_individual.append(joint.limits[1])
+    iiwa_low, iiwa_high = chain.get_joint_limits()
+    assert iiwa_low == iiwa_low_individual
+    assert iiwa_high == iiwa_high_individual
     chain = pk.build_chain_from_urdf(open(os.path.join(TEST_DIR, "joint_limit_robot.urdf")).read())
+    nums = []
     for joint in chain.get_joints():
         # Slice off the "joint" prefix to get just the number of the joint
         num = int(joint.name[5])
-        # This robot is defined specifically to test joint limits. It always
-        # sets velocity limits equal to the joint number and effort limits
-        # equal to the joint number + 4
+        nums.append(num)
+        # This robot is defined specifically to test joint limits. For joint
+        # number `num`, it sets lower, upper, velocity, and effort limits to
+        # `num+8`, `num+9`, `num`, and `num+4` respectively
+        assert joint.limits == (num + 8, num + 9)
         assert joint.velocity_limits == (-num, num)
         assert joint.effort_limits == (-(num + 4), num + 4)
+    low, high = chain.get_joint_limits()
+    v_low, v_high = chain.get_joint_velocity_limits()
+    e_low, e_high = chain.get_joint_effort_limits()
+    assert low == [x + 8 for x in nums]
+    assert high == [x + 9 for x in nums]
+    assert v_low == [-x for x in nums]
+    assert v_high == [x for x in nums]
+    assert e_low == [-(x + 4) for x in nums]
+    assert e_high == [x + 4 for x in nums]
+
+
+def test_empty_limits():
+    chain = pk.build_chain_from_urdf(open(os.path.join(TEST_DIR, "joint_no_limit_robot.urdf")).read())
+    nums = []
+    for joint in chain.get_joints():
+        # Slice off the "joint" prefix to get just the number of the joint
+        num = int(joint.name[5])
+        nums.append(num)
+        # This robot is defined specifically to test joint limits. For joint
+        # number `num`, it sets velocity, and effort limits to
+        # `num`, and `num+4` respectively, and leaves the lower and upper
+        # limits undefined
+        assert joint.limits == (0, 0)
+        assert joint.velocity_limits == (-num, num)
+        assert joint.effort_limits == (-(num + 4), num + 4)
+    low, high = chain.get_joint_limits()
+    v_low, v_high = chain.get_joint_velocity_limits()
+    e_low, e_high = chain.get_joint_effort_limits()
+    assert low == [0] * len(nums)
+    assert high == [0] * len(nums)
+    assert v_low == [-x for x in nums]
+    assert v_high == [x for x in nums]
+    assert e_low == [-(x + 4) for x in nums]
+    assert e_high == [x + 4 for x in nums]
 
 
 if __name__ == "__main__":
     test_limits()
+    test_empty_limits()


### PR DESCRIPTION
Add in optional `velocity_limits` and `effort_limits` attributes to the `Joint` class. Modified URDF parsing to populate these fields when possible. Both are stored as tuples of (lower, upper) limits on the respective field.
- URDF only supports symmetric velocity and effort limits but MJCF supports asymmetric effort limits. A tuple is used for API consistency across the two formats. URDF parsing simply assigns the tuple as (-lim, lim).
- Additionally added a robot (joint_limit_robot.urdf) to test the attribute access and a test (test_attributes.py) to validate. test_attributes.py also loads the iiwa URDF and assumes its velocity limits are (-10, 10) and effort limits are (-300, 300).

When running the existing tests, all tests related to MJCF files failed for me in the original clone of the repo due to an import error, so I decided not to adjust MJCF parsing. The remaining tests all appeared to pass.

Closes https://github.com/UM-ARM-Lab/pytorch_kinematics/issues/52